### PR TITLE
Initial implementation of the json parser 

### DIFF
--- a/aggcat/json_parser.py
+++ b/aggcat/json_parser.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+
+import json
+
+from .parser import ObjectifyBase
+
+__all__ = ['JsonObjectify']
+
+def _repr(self):
+    if hasattr(self, '_list'):
+        ls = [repr(l) for l in self._list[:2]]
+        return '<{} object [{} ...] @ {}>'.format(self._name, ','.join(ls), hex(id(self)))
+    else:
+        return '<{} object @ {}>'.format(self._name, hex(id(self)))
+
+def _objectify_getattr(self, name):
+    
+    if name in self.__dict__:
+        return self.__dict__[name]
+    
+    if name in self._keys:
+        tree = self._tree.pop(self._keys[name])
+        
+        if isinstance(tree, (list, tuple)):
+            obj = self.__parent__._create_list_object(name, tree)
+            name = obj._name
+        elif isinstance(tree, dict):
+            obj = self.__parent__._create_object(name, tree)
+            name = obj._name
+        else:
+            obj = tree
+        
+        self.__dict__[name] = obj
+        return obj
+        
+    return getattr(super(type(self), self), name)
+
+def _objectify_getitem(self, idx):
+        obj = self._list[idx]
+        if not hasattr(obj, '_name'):
+            name = '{}item'.format(self.__class__.__name__.lower())
+            
+            if isinstance(obj, (list, tuple)):
+                obj = self.__parent__._create_list_object(name, obj)
+            else:
+                obj = self.__parent__._create_object(name, obj)
+            
+            self._list[idx] = obj
+        return obj
+
+class JsonObjectify(ObjectifyBase):
+    application_type = 'application/json'
+    error_type = ValueError
+    
+    def __init__(self, json_str):
+        json_data = json.loads(json_str) #: :type json_data: dict
+        
+        assert len(json_data.keys()) == 1, "There can be only one (root)"
+        
+        root_tag, tree = json_data.popitem()
+        
+        if isinstance(tree, (list, tuple)):
+            self.obj = self._create_list_object(root_tag, tree)
+        else:
+            self.obj = self._create_object(root_tag, tree = tree)
+    
+    def _create_object(self, name, tree = None, attributes = None, bases = None):
+        name = self.clean_tag_name(name)
+        
+        if attributes is None:
+            attributes = {}
+        
+        if bases is None:
+            bases = (object,)
+        
+        attributes.update({
+            '__parent__' : self,
+            '_name' : name,
+            '__repr__' : _repr,
+            '__getattr__' : _objectify_getattr,
+            '_keys' : [],
+            '_tree' : tree
+        })
+        
+        if tree is not None:
+            attributes['_keys'] = {
+                self.clean_tag_name(k) : k for k in tree.keys()
+            }
+        
+        return type(str(name.capitalize()), bases, attributes)()
+    
+    def _create_list_object(self, name, list_objects = None):
+        if list_objects is None:
+            list_objects = []
+        
+        obj = self._create_object(name, attributes = {
+            '__parent__' : self,
+            '_list' : [],
+            '__len__' : lambda this: len(this._list),
+            '__iter__' : lambda this: iter(this._list),
+            '__getitem__' : _objectify_getitem
+        }, bases = (list,))
+        
+        obj._list = list_objects
+        return obj
+        
+    
+    def get_object(self):
+        return self.obj
+        

--- a/aggcat/parser.py
+++ b/aggcat/parser.py
@@ -1,143 +1,18 @@
-from __future__ import absolute_import
-
 import re
-from lxml import etree
 
-try:
-    from collections import Counter
-except ImportError:
-    from .counter import Counter
+__all__ = ['ObjectifyBase']
 
-from .utils import remove_namespaces
+tag_pattern = re.compile("(?!^)(401[kK]|[A-Z]+)")
 
-
-def _get_item(self, index):
-    return self._list[index]
-
-
-def _len(self):
-    return len(self._list)
-
-
-def _iter(self):
-    return iter(self._list)
-
-
-def _repr(self):
-    if hasattr(self, '_list'):
-        ls = [repr(l) for l in self._list[:2]]
-        return '<%s object [%s ...] @ %s>' % (self._name, ','.join(ls), hex(id(self)))
-    else:
-        return '<%s object @ %s>' % (self._name, hex(id(self)))
-
-
-class Objectify(object):
-    """Take XML output and turn it into a Pythonic Object
-    The goals are to:
-       * Provide an object that resembles the XML structure
-       * Have the ability to go back to XML from the object
-    """
-    def __init__(self, xml):
-        # raw xml
-        self.xml = xml
-
-        # parse the tree with lxml
-        self.tree = etree.fromstring(remove_namespaces(etree.XML(xml)))
-
-        # regex pattern for tag name cleanup
-        self.tag_pattern = re.compile("(?!^)([A-Z]+)")
-
-        self.root_tag = self.tree.tag
-
-        # create a base object wrapper
-        self.obj = self._create_object('Objectified XML')
-
-        # check to see this is only one node with no children
-        # Ex. get_customer_accounts is empty
-        if not self.tree.getchildren():
-            self.obj = self._create_object(self.tree.tag)
-        else:
-            self._walk_and_objectify(self.tree, self.obj)
-
-    def _create_object(self, name, attributes={}):
-        """Dynamically create an object"""
-        attributes.update({
-            '_name': name.capitalize(),
-            '__repr__': _repr
-        })
-        return type(name.capitalize(), (object,), attributes)()
-
-    def _create_list_object(self, name):
-        """Dynamically create an object that has list type functionality"""
-        return self._create_object(name, {
-            '_list': [],
-            '__len__': _len,
-            '__iter__': _iter,
-            '__getitem__': _get_item
-        })
-
-    def _clean_tag_name(self, tag_name):
+class ObjectifyBase(object):
+    
+    application_type = ''
+    error_type = Exception
+    
+    def get_object(self):
+        raise NotImplementedError()
+    
+    def clean_tag_name(self, tag_name):
         """Convert the CamelCase format of tag name to
         a camel_case format"""
-        return re.sub(self.tag_pattern, r'_\1', tag_name).lower()
-
-    def _is_list_xml(self, element):
-        """Detect if the next set of XML elements contain duplicates
-        which means it is a listable set of elements"""
-        tags = []
-        for e in element.xpath('./*'):
-            tags.append(e.tag)
-
-        for count in Counter(tags).values():
-            if count > 1:
-                return True
-
-        return False
-
-    def _walk_and_objectify(self, element, obj):
-        """Walk the XML tree recursively and make objects out of the structure"""
-        if element.getchildren():
-            # look ahead and create a list object instead
-            needs_list_obj = self._is_list_xml(element)
-
-            if needs_list_obj:
-                new_obj = self._create_list_object(element.tag)
-            else:
-                new_obj = self._create_object(element.tag)
-
-            obj_attr_value = getattr(obj, element.tag, None)
-            has_list = hasattr(obj, '_list')
-
-            if obj_attr_value is None and not has_list:
-                setattr(obj, element.tag, new_obj)
-            else:
-                l = getattr(obj, '_list')
-                l.append(new_obj)
-                setattr(obj, '_list', l)
-
-            for child in element.getchildren():
-                self._walk_and_objectify(child, new_obj)
-        else:
-            setattr(obj, self._clean_tag_name(element.tag), element.text)
-
-    def get_object(self):
-        root_obj = self.obj
-
-        if hasattr(self.obj, self.root_tag):
-            root_obj = getattr(self.obj, self.root_tag)
-
-        # sometimes there is only one attribute that is a converted object
-        # return this one instead of the surrounding object. I am not
-        # sure this is the desired result, but i'll leave it for now
-        appended_attrs = [
-            k for k
-            in root_obj.__dict__.iterkeys()
-            if not k.startswith('_') and not '_' in k
-        ]
-        if len(appended_attrs) == 1:
-            root_obj = getattr(root_obj, appended_attrs.pop())
-
-        # append the to_xml() attribute to you can easily get the xml from the root object
-        root_obj.to_xml = lambda: self.xml
-
-        return root_obj
+        return re.sub(tag_pattern, r'_\1', tag_name).lower()

--- a/aggcat/tests/data/sample_json.json
+++ b/aggcat/tests/data/sample_json.json
@@ -1,0 +1,38 @@
+{
+"recipies": [
+	{
+		"name": "Fried Pickles",
+		"prepTime": "15",
+		"cookTime": "30",
+		"ingredients": [
+			{
+				"name": "Flour",
+				"amount": "1 cup"
+			},
+			{
+				"name": "Pickles",
+				"amount": "2 cups"
+			}
+		]
+	},
+	{
+		"name": "Smoked Bacon",
+		"prepTime": "5",
+		"cookTime": "10",
+		"ingredients":  [
+			{
+				"name": "Bacon",
+				"amount": "1 cup"
+			},
+			{
+				"name": "Wood Chips",
+				"amount": "1/2 Bag"
+			},
+			{
+				"name": "Cavendars",
+				"amount": "1 tsp"
+			}
+		]
+	}
+]
+}

--- a/aggcat/tests/test_client.py
+++ b/aggcat/tests/test_client.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from ..client import AggcatClient
 from ..exceptions import HTTPError
+from ..xml_parser import XmlObjectify
 
 from nose.tools import raises, nottest
 
@@ -34,7 +35,7 @@ class TestClient(object):
             client_config.get('aggcat', 'private_key'),
         )
 
-        self.ac = AggcatClient(*self.client_args, objectify=True)
+        self.ac = AggcatClient(*self.client_args, objectify = XmlObjectify)
 
     @classmethod
     def teardown_class(self):

--- a/aggcat/tests/test_parser.py
+++ b/aggcat/tests/test_parser.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from ..parser import Objectify
+from ..xml_parser import XmlObjectify
+from ..json_parser import JsonObjectify
 
 
 class TestParser(object):
@@ -8,8 +9,12 @@ class TestParser(object):
     @classmethod
     def setup_class(self):
         self.o = None
+        self.j = None
         with open('aggcat/tests/data/sample_xml.xml', 'r') as f:
-            self.o = Objectify(f.read()).get_object()
+            self.o = XmlObjectify(f.read()).get_object()
+        
+        with open('aggcat/tests/data/sample_json.json', 'r') as fp:
+            self.j = JsonObjectify(fp.read()).get_object()
 
     def test_lists(self):
         """Parser Test: Lists object added are correct"""
@@ -18,6 +23,12 @@ class TestParser(object):
         assert len(self.o) == 2
         assert len(self.o[0].ingredients) == 2
         assert len(self.o[1].ingredients) == 3
+        
+        assert hasattr(self.j, '_list')
+        assert isinstance(self.j._list, list) == True
+        assert len(self.j) == 2
+        assert len(self.j[0].ingredients) == 2
+        assert len(self.j[1].ingredients) == 3
 
     def test_attributes(self):
         """Parser Test: object attributes created have correct value"""
@@ -28,3 +39,23 @@ class TestParser(object):
         assert self.o[0].ingredients[0].name == 'Flour'
         assert self.o[1].name == 'Smoked Bacon'
         assert self.o[1].ingredients[0].name == 'Bacon'
+        
+        assert hasattr(self.j[0], 'name')
+        assert hasattr(self.j[0], 'ingredients')
+        assert hasattr(self.j[0], 'cook_time')
+        assert self.j[0].name == 'Fried Pickles'
+        assert self.j[0].ingredients[0].name == 'Flour'
+        assert self.j[1].name == 'Smoked Bacon'
+        assert self.j[1].ingredients[0].name == 'Bacon'
+        
+        try:
+            self.j[0].bad_attr
+            assert False
+        except AttributeError:
+            pass
+        
+        try:
+            self.j[123]
+            assert False
+        except IndexError:
+            pass

--- a/aggcat/xml_parser.py
+++ b/aggcat/xml_parser.py
@@ -1,0 +1,132 @@
+from __future__ import absolute_import
+
+from lxml import etree
+
+try:
+    from collections import Counter
+except ImportError:
+    from .counter import Counter
+
+from .utils import remove_namespaces
+from .parser import ObjectifyBase
+
+def _get_item(self, index):
+    return self._list[index]
+
+
+def _len(self):
+    return len(self._list)
+
+
+def _iter(self):
+    return iter(self._list)
+
+
+def _repr(self):
+    if hasattr(self, '_list'):
+        ls = [repr(l) for l in self._list[:2]]
+        return '<%s object [%s ...] @ %s>' % (self._name, ','.join(ls), hex(id(self)))
+    else:
+        return '<%s object @ %s>' % (self._name, hex(id(self)))
+
+
+class XmlObjectify(ObjectifyBase):
+    """Take XML output and turn it into a Pythonic Object
+    The goals are to:
+     * Provide an object that resembles the XML structure
+     * Have the ability to go back to XML from the object
+    """
+    application_type = 'application/xml'
+    error_type = etree.XMLSyntaxError
+    
+    def __init__(self, xml):
+        # raw xml
+        self.xml = xml
+
+        # parse the tree with lxml
+        self.tree = etree.fromstring(remove_namespaces(etree.XML(xml)))
+
+        self.root_tag = self.tree.tag
+
+        # create a base object wrapper
+        self.obj = self._create_object('Objectified XML')
+
+        # check to see this is only one node with no children
+        # Ex. get_customer_accounts is empty
+        if not self.tree.getchildren():
+            self.obj = self._create_object(self.tree.tag)
+        else:
+            self._walk_and_objectify(self.tree, self.obj)
+
+    def _create_object(self, name, attributes = None):
+        """Dynamically create an object"""
+        if attributes is None:
+            attributes = {}
+        attributes.update({
+            '_name': name.capitalize(),
+            '__repr__': _repr
+        })
+        return type(name.capitalize(), (object,), attributes)()
+
+    def _create_list_object(self, name):
+        """Dynamically create an object that has list type functionality"""
+        return self._create_object(name, {
+            '_list': [],
+            '__len__': _len,
+            '__iter__': _iter,
+            '__getitem__': _get_item
+        })
+
+    def _is_list_xml(self, element):
+        """Detect if the next set of XML elements contain duplicates
+        which means it is a listable set of elements"""
+        tags = [ e.tag for e in element.xpath('./*')]
+        return any(count > 1 for count in Counter(tags).values())
+
+    def _walk_and_objectify(self, element, obj):
+        """Walk the XML tree recursively and make objects out of the structure"""
+        if element.getchildren():
+            # look ahead and create a list object instead
+            needs_list_obj = self._is_list_xml(element)
+
+            if needs_list_obj:
+                new_obj = self._create_list_object(element.tag)
+            else:
+                new_obj = self._create_object(element.tag)
+
+            obj_attr_value = getattr(obj, element.tag, None)
+            has_list = hasattr(obj, '_list')
+
+            if obj_attr_value is None and not has_list:
+                setattr(obj, element.tag, new_obj)
+            else:
+                l = getattr(obj, '_list')
+                l.append(new_obj)
+                setattr(obj, '_list', l)
+
+            for child in element.getchildren():
+                self._walk_and_objectify(child, new_obj)
+        else:
+            setattr(obj, self.clean_tag_name(element.tag), element.text)
+
+    def get_object(self):
+        root_obj = self.obj
+
+        if hasattr(self.obj, self.root_tag):
+            root_obj = getattr(self.obj, self.root_tag)
+
+        # sometimes there is only one attribute that is a converted object
+        # return this one instead of the surrounding object. I am not
+        # sure this is the desired result, but i'll leave it for now
+        appended_attrs = [
+            k for k
+            in root_obj.__dict__.iterkeys()
+            if not k.startswith('_') and not '_' in k
+        ]
+        if len(appended_attrs) == 1:
+            root_obj = getattr(root_obj, appended_attrs.pop())
+
+        # append the to_xml() attribute to you can easily get the xml from the root object
+        root_obj.to_xml = lambda: self.xml
+
+        return root_obj


### PR DESCRIPTION
This patch adds initial support for the json response type from intuit. It adds a objectifier class which lazily converts the json response into objects.

One other change is the tag pattern regex for converting camelCase to underscore_case, I changed it to take into account "401K" which originally was being converted to "401_k", and now is converted to "401k".

I've only written basic tests to make sure the objectifier adheres to the same interface as the original xml implementation 

Partial fix for #6
